### PR TITLE
feat: add email_save_attachment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ npx @marlinjai/email-mcp setup
 | `email_remove_account` | Remove an account and its stored credentials |
 | `email_test_account` | Test connection to an account |
 
-### Reading & Searching (5)
+### Reading & Searching (6)
 
 | Tool | Description |
 |------|-------------|
@@ -123,6 +123,7 @@ npx @marlinjai/email-mcp setup
 | `email_get` | Get full email content by ID (headers, body, attachment metadata) |
 | `email_get_thread` | Get an entire email thread/conversation |
 | `email_get_attachment` | Download a specific attachment by ID (returns base64 data) |
+| `email_save_attachment` | Download an attachment and save directly to a file path. Returns metadata only — avoids base64 in response (fast for large files) |
 
 ### Sending & Drafts (5)
 

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AccountManager } from '../account-manager.js';
@@ -140,6 +142,37 @@ export function registerReadingTools(server: McpServer, accountManager: AccountM
         return jsonResult({
           data: Buffer.from(data).toString('base64'),
           meta,
+        });
+      } catch (error: any) {
+        return jsonResult({ error: error.message });
+      }
+    },
+  );
+
+  // --- email_save_attachment ---
+  server.tool(
+    'email_save_attachment',
+    'Download an email attachment and save it directly to a file path. Returns metadata only (no base64 data in response), avoiding token costs for large attachments.',
+    {
+      accountId: z.string(),
+      emailId: z.string(),
+      attachmentId: z.string(),
+      outputPath: z.string().describe('Absolute file path where the attachment should be saved'),
+    },
+    async (args) => {
+      try {
+        const provider = await accountManager.getProvider(args.accountId);
+        const { data, meta } = await provider.getAttachment(args.emailId, args.attachmentId);
+
+        const absPath = path.resolve(args.outputPath);
+        fs.mkdirSync(path.dirname(absPath), { recursive: true });
+        fs.writeFileSync(absPath, Buffer.from(data));
+
+        return jsonResult({
+          path: absPath,
+          bytes: data.length,
+          filename: meta.filename,
+          mimeType: meta.mimeType,
         });
       } catch (error: any) {
         return jsonResult({ error: error.message });


### PR DESCRIPTION
## Summary

Adds a new `email_save_attachment` tool that writes attachment data directly to disk server-side and returns only metadata. Complements the existing `email_get_attachment` (which returns base64) for cases where the consumer just wants the file saved.

## Motivation

When using this MCP with an LLM client, large attachments are expensive to move through the model's context. A 42KB xlsx becomes ~57KB of base64 in the tool response, then the model typically has to echo that base64 back out as a Write tool argument to save it — paying tokens twice for the same blob.

`email_save_attachment` skips the round-trip: the server writes the file, the client gets back `{ path, bytes, filename, mimeType }`.

## Changes

- New tool `email_save_attachment` in `src/tools/reading.ts`
- Reuses existing `provider.getAttachment()` — no provider interface changes
- Creates parent directory if missing, resolves to absolute path
- `email_get_attachment` is untouched (backward compatible)
- README updated with new tool row

## Testing

Verified locally against both Gmail and Outlook accounts. Successfully downloaded xlsx and PDF attachments to disk with correct file size and content. Existing `email_get_attachment` behavior unchanged.