### PR TITLE
fix(imap): resolve Gmail drafts folder instead of hardcoding 'Drafts'

### DIFF
--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -513,7 +513,11 @@ export class ImapAdapter implements EmailProvider {
     lines.push(params.body.text || '');
 
     const rawMessage = lines.join('\r\n');
-    const result = await this.client.append('Drafts', rawMessage, ['\\Draft', '\\Seen']);
+    // Resolve the real drafts mailbox instead of assuming a top-level "Drafts"
+    // folder. Gmail (and localized accounts) expose it as "[Gmail]/Drafts" /
+    // "[Gmail]/Entwürfe", so a hardcoded path makes append fail. See issue #3.
+    const draftsFolder = await this.resolveFolder('Drafts');
+    const result = await this.client.append(draftsFolder, rawMessage, ['\\Draft', '\\Seen']);
     return { id: String(result.uid || result) };
   }
 

--- a/tests/providers/imap.test.ts
+++ b/tests/providers/imap.test.ts
@@ -539,6 +539,63 @@ describe('ImapAdapter threads, drafts, attachments', () => {
     expect(drafts).toHaveLength(1);
   });
 
+  // Regression: Gmail exposes drafts via IMAP under "[Gmail]/Drafts" (or a
+  // localized name like "[Gmail]/Entwürfe"), not a top-level "Drafts" mailbox.
+  // createDraft/listDrafts must resolve the real folder instead of hardcoding
+  // "Drafts", otherwise both operations fail on Gmail accounts. See issue #3.
+  const gmailFolders = [
+    { path: 'INBOX', name: 'INBOX', specialUse: '\\Inbox' },
+    { path: '[Gmail]/Drafts', name: 'Drafts', specialUse: '\\Drafts' },
+    { path: '[Gmail]/Sent Mail', name: 'Sent Mail', specialUse: '\\Sent' },
+    { path: '[Gmail]/Trash', name: 'Trash', specialUse: '\\Trash' },
+  ];
+
+  it('createDraft resolves the Gmail drafts folder before appending', async () => {
+    const client = (adapter as any).client;
+    client.list.mockResolvedValue(gmailFolders);
+
+    await adapter.createDraft({
+      to: [{ email: 'bob@test.com' }],
+      subject: 'Draft subject',
+      body: { text: 'Draft body' },
+    });
+
+    expect(client.append).toHaveBeenCalledWith(
+      '[Gmail]/Drafts',
+      expect.any(String),
+      expect.arrayContaining(['\\Draft', '\\Seen']),
+    );
+  });
+
+  it('createDraft resolves a localized Gmail drafts folder via special-use flag', async () => {
+    const client = (adapter as any).client;
+    client.list.mockResolvedValue([
+      { path: 'INBOX', name: 'INBOX', specialUse: '\\Inbox' },
+      { path: '[Gmail]/Entwürfe', name: 'Entwürfe', specialUse: '\\Drafts' },
+    ]);
+
+    await adapter.createDraft({
+      to: [{ email: 'bob@test.com' }],
+      subject: 'Draft subject',
+      body: { text: 'Draft body' },
+    });
+
+    expect(client.append).toHaveBeenCalledWith(
+      '[Gmail]/Entwürfe',
+      expect.any(String),
+      expect.arrayContaining(['\\Draft', '\\Seen']),
+    );
+  });
+
+  it('listDrafts resolves the Gmail drafts folder before searching', async () => {
+    const client = (adapter as any).client;
+    client.list.mockResolvedValue(gmailFolders);
+
+    await adapter.listDrafts();
+
+    expect(client.getMailboxLock).toHaveBeenCalledWith('[Gmail]/Drafts');
+  });
+
   it('getAttachment fetches email and extracts attachment', async () => {
     // Override simpleParser mock for this test to return an attachment
     const { simpleParser: mockParser } = await import('mailparser');


### PR DESCRIPTION
## Problem

`ImapAdapter.createDraft` appends to a hardcoded `"Drafts"` mailbox:

```ts
const result = await this.client.append('Drafts', rawMessage, ['\\Draft', '\\Seen']);
```

Gmail accounts connected over "Other IMAP" (`imap.gmail.com`) expose drafts as `[Gmail]/Drafts` (or a localized name such as `[Gmail]/Entwuerfe`), so there is no top-level `Drafts` mailbox. Draft creation therefore fails with a folder-not-found error. This is the bug reported in #3.

## Fix

Resolve the real drafts mailbox via the adapter's existing `resolveFolder()` helper, which already handles provider-specific folder paths and `\Drafts` special-use flags (it is already used by `search`, `moveEmail`, delete, etc.):

```ts
const draftsFolder = await this.resolveFolder('Drafts');
const result = await this.client.append(draftsFolder, rawMessage, ['\\Draft', '\\Seen']);
```

Minimal, surgical change -- only `createDraft` hardcoded the path. `listDrafts` already routes through `search`, which resolves the folder; a regression test now locks that in.

## Tests (TDD -- added failing first, then fixed)

New tests in `tests/providers/imap.test.ts`:
- `createDraft resolves the Gmail drafts folder before appending` -> asserts `append` is called with `[Gmail]/Drafts`
- `createDraft resolves a localized Gmail drafts folder via special-use flag` -> localized folder resolved through the `\Drafts` special-use flag
- `listDrafts resolves the Gmail drafts folder before searching` -> asserts the lock opens `[Gmail]/Drafts`

Validation:
- `npx vitest run tests/providers/imap.test.ts -t "raft"` -> all draft/Gmail tests pass; existing `createDraft appends message to Drafts` still passes (default servers with a top-level `Drafts` folder resolve to `Drafts` unchanged).
- `npm run build` -> succeeds.

Note: two pre-existing `listDrafts` test failures (search mock does not set `client.mailbox.exists`) exist on `main` independently of this change and are intentionally left untouched to keep the patch focused.

Fixes #3
