### PR TITLE
fix(credential-store): stable machine-id key derivation + EMAIL_MCP_KEY (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,25 @@ pnpm test:watch
 pnpm test:integration
 ```
 
+## Credential Storage
+
+Account credentials are encrypted at rest with AES-256-GCM in `~/.email-mcp/credentials.enc`.
+
+By default the encryption key is derived from a stable, machine-specific identifier
+(the hardware UUID on macOS, `/etc/machine-id` on Linux, or the `MachineGuid` on
+Windows), falling back to the hostname when none is available.
+
+Set the `EMAIL_MCP_KEY` environment variable to supply your own passphrase instead.
+This is recommended when the machine identifier may change (for example in
+containers or CI), or when you want to move `credentials.enc` between machines:
+
+```bash
+export EMAIL_MCP_KEY="your-strong-passphrase"
+```
+
+When `EMAIL_MCP_KEY` is set, existing credential files are transparently
+re-encrypted with the passphrase the next time they are read.
+
 ## Support
 
 If this project is useful to you, consider supporting its development:

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -10,17 +11,89 @@ const IV_LENGTH = 16;
 const SALT_LENGTH = 32;
 const PBKDF2_ITERATIONS = 100_000;
 
-function getMachineSeed(): string {
-  return `email-mcp:${os.hostname()}:${os.userInfo().username}`;
+let cachedMachineId: string | null | undefined;
+
+/**
+ * Returns a hardware/OS identifier that is stable across reboots and network
+ * changes. Unlike os.hostname(), these values do not change when macOS
+ * renumbers its mDNS/Bonjour name on a naming conflict (see issue #4), which
+ * would otherwise make credentials.enc permanently undecryptable.
+ *
+ * Returns null when no stable identifier can be obtained, in which case the
+ * caller falls back to the legacy hostname-based seed.
+ */
+function getStableMachineId(): string | null {
+  if (cachedMachineId !== undefined) return cachedMachineId;
+  cachedMachineId = computeStableMachineId();
+  return cachedMachineId;
 }
 
-function deriveKey(salt: Buffer): Buffer {
-  return crypto.pbkdf2Sync(getMachineSeed(), salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha512');
+function computeStableMachineId(): string | null {
+  try {
+    if (process.platform === 'darwin') {
+      const out = execFileSync('ioreg', ['-rd1', '-c', 'IOPlatformExpertDevice'], {
+        encoding: 'utf-8',
+      });
+      const match = out.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/);
+      return match ? match[1] : null;
+    }
+    if (process.platform === 'linux') {
+      for (const p of ['/etc/machine-id', '/var/lib/dbus/machine-id']) {
+        if (fs.existsSync(p)) {
+          const id = fs.readFileSync(p, 'utf-8').trim();
+          if (id) return id;
+        }
+      }
+      return null;
+    }
+    if (process.platform === 'win32') {
+      const out = execFileSync(
+        'reg',
+        ['query', 'HKLM\\SOFTWARE\\Microsoft\\Cryptography', '/v', 'MachineGuid'],
+        { encoding: 'utf-8' },
+      );
+      const match = out.match(/MachineGuid\s+REG_SZ\s+([A-Za-z0-9-]+)/);
+      return match ? match[1] : null;
+    }
+  } catch {
+    // ioreg/reg unavailable or failed — fall back to the hostname-based seed.
+  }
+  return null;
 }
 
-function encrypt(plaintext: string): string {
+/**
+ * Ordered list of seed candidates used to derive the encryption key.
+ *
+ * The first entry is the preferred (most stable) seed used for new writes; the
+ * remaining entries let credential files written by an older version — or
+ * before a hostname change — still be decrypted, after which they are
+ * transparently re-encrypted with the preferred seed.
+ */
+function getSeedCandidates(): string[] {
+  const seeds: string[] = [];
+  const username = os.userInfo().username;
+
+  // 1. Explicit user-provided key always wins and is fully portable.
+  const envKey = process.env.EMAIL_MCP_KEY;
+  if (envKey) seeds.push(`email-mcp:env:${envKey}`);
+
+  // 2. Stable hardware/machine identifier (survives mDNS hostname drift).
+  const machineId = getStableMachineId();
+  if (machineId) seeds.push(`email-mcp:machine:${machineId}:${username}`);
+
+  // 3. Legacy hostname-based seed for backward compatibility / migration.
+  seeds.push(`email-mcp:${os.hostname()}:${username}`);
+
+  return seeds;
+}
+
+function deriveKey(seed: string, salt: Buffer): Buffer {
+  return crypto.pbkdf2Sync(seed, salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha512');
+}
+
+function encrypt(plaintext: string, seed: string): string {
   const salt = crypto.randomBytes(SALT_LENGTH);
-  const key = deriveKey(salt);
+  const key = deriveKey(seed, salt);
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
 
@@ -36,15 +109,33 @@ function encrypt(plaintext: string): string {
   });
 }
 
-function decrypt(ciphertext: string): string {
+/**
+ * Attempts to decrypt the ciphertext against each seed candidate in order,
+ * returning the plaintext and the seed that succeeded so the caller can detect
+ * (and migrate away from) legacy seeds.
+ */
+function decrypt(ciphertext: string, seeds: string[]): { plaintext: string; seedUsed: string } {
   const { salt, iv, authTag, data } = JSON.parse(ciphertext);
-  const key = deriveKey(Buffer.from(salt, 'hex'));
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, 'hex'));
-  decipher.setAuthTag(Buffer.from(authTag, 'hex'));
+  const saltBuf = Buffer.from(salt, 'hex');
+  const ivBuf = Buffer.from(iv, 'hex');
+  const authTagBuf = Buffer.from(authTag, 'hex');
+  let lastError: unknown;
 
-  let decrypted = decipher.update(data, 'hex', 'utf-8');
-  decrypted += decipher.final('utf-8');
-  return decrypted;
+  for (const seed of seeds) {
+    try {
+      const key = deriveKey(seed, saltBuf);
+      const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuf);
+      decipher.setAuthTag(authTagBuf);
+
+      let decrypted = decipher.update(data, 'hex', 'utf-8');
+      decrypted += decipher.final('utf-8');
+      return { plaintext: decrypted, seedUsed: seed };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  throw lastError ?? new Error('Unable to decrypt credentials');
 }
 
 interface StoredData {
@@ -67,13 +158,25 @@ export class CredentialStore {
       return { accounts: {} };
     }
     const raw = fs.readFileSync(this.filePath, 'utf-8');
-    const json = decrypt(raw);
-    return JSON.parse(json);
+    const seeds = getSeedCandidates();
+    const { plaintext, seedUsed } = decrypt(raw, seeds);
+    const data = JSON.parse(plaintext) as StoredData;
+
+    // Transparently re-encrypt with the preferred seed when an older/legacy
+    // seed was used, so future reads survive hostname changes (issue #4).
+    if (seedUsed !== seeds[0]) {
+      try {
+        this.write(data);
+      } catch {
+        // Migration is best-effort; the read itself already succeeded.
+      }
+    }
+    return data;
   }
 
   private write(data: StoredData): void {
     const json = JSON.stringify(data);
-    const encrypted = encrypt(json);
+    const encrypted = encrypt(json, getSeedCandidates()[0]);
     fs.writeFileSync(this.filePath, encrypted, { mode: 0o600 });
   }
 

--- a/tests/auth/credential-store.test.ts
+++ b/tests/auth/credential-store.test.ts
@@ -123,4 +123,71 @@ describe('CredentialStore', () => {
     const all = await store.list();
     expect(all).toHaveLength(1);
   });
+
+  describe('encryption key stability (issue #4)', () => {
+    let savedEnvKey: string | undefined;
+
+    beforeEach(() => {
+      savedEnvKey = process.env.EMAIL_MCP_KEY;
+      delete process.env.EMAIL_MCP_KEY;
+    });
+
+    afterEach(() => {
+      if (savedEnvKey === undefined) {
+        delete process.env.EMAIL_MCP_KEY;
+      } else {
+        process.env.EMAIL_MCP_KEY = savedEnvKey;
+      }
+    });
+
+    const sampleCreds = (id: string) => ({
+      id,
+      name: 'Sample',
+      provider: ProviderType.Gmail as const,
+      email: `${id}@gmail.com`,
+      oauth: { access_token: 'a', refresh_token: 'r', expiry: '' },
+    });
+
+    it('encrypts and decrypts using EMAIL_MCP_KEY when provided', async () => {
+      process.env.EMAIL_MCP_KEY = 'a-portable-passphrase';
+      const s = new CredentialStore(testDir);
+      await s.save(sampleCreds('env-1'));
+
+      const s2 = new CredentialStore(testDir);
+      const loaded = await s2.get('env-1');
+      expect(loaded?.email).toBe('env-1@gmail.com');
+    });
+
+    it('migrates a legacy-seeded file to EMAIL_MCP_KEY on read', async () => {
+      // Written without an explicit key (machine/hostname-derived seed).
+      const legacyStore = new CredentialStore(testDir);
+      await legacyStore.save(sampleCreds('mig-1'));
+
+      // Now an explicit key is configured: the existing file must still be
+      // readable and should be transparently re-encrypted with the new key.
+      process.env.EMAIL_MCP_KEY = 'new-passphrase';
+      const upgraded = new CredentialStore(testDir);
+      expect((await upgraded.get('mig-1'))?.email).toBe('mig-1@gmail.com');
+
+      // After migration the on-disk file decrypts with the new key, even from a
+      // fresh instance, confirming the rewrite happened.
+      const afterMigration = new CredentialStore(testDir);
+      expect((await afterMigration.get('mig-1'))?.email).toBe('mig-1@gmail.com');
+
+      // ...and it can no longer be decrypted without the key.
+      delete process.env.EMAIL_MCP_KEY;
+      const withoutKey = new CredentialStore(testDir);
+      await expect(withoutKey.get('mig-1')).rejects.toThrow();
+    });
+
+    it('fails to decrypt with the wrong EMAIL_MCP_KEY', async () => {
+      process.env.EMAIL_MCP_KEY = 'correct-key';
+      const s = new CredentialStore(testDir);
+      await s.save(sampleCreds('wrong-1'));
+
+      process.env.EMAIL_MCP_KEY = 'a-different-key';
+      const s2 = new CredentialStore(testDir);
+      await expect(s2.get('wrong-1')).rejects.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`CredentialStore` derives its AES-256-GCM key from `os.hostname()`:

```js
const seed = `email-mcp:${os.hostname()}:${os.userInfo().username}`;
```

As reported in #4, `os.hostname()` is **not stable** on macOS — the mDNS/Bonjour
name gets a numeric suffix when a naming conflict is detected (switching
networks, waking from sleep, another device with the same name). When it
changes, the derived key no longer matches and `credentials.enc` becomes
undecryptable (`Unsupported state or unable to authenticate data`), crashing the
server on startup. The only recovery was deleting the file and re-running setup.

## Fix

Derive the key from a **stable** identifier, with graceful fallback:

| Platform | Source |
| --- | --- |
| macOS | `IOPlatformUUID` via `ioreg` |
| Linux | `/etc/machine-id` (or dbus machine-id) |
| Windows | `HKLM\SOFTWARE\Microsoft\Cryptography` `MachineGuid` |
| fallback | `os.hostname()` (previous behaviour) |

Also adds an explicit **`EMAIL_MCP_KEY`** passphrase override (the issue's
suggestion 3) for full portability — useful in containers/CI or to move the
file between machines.

### Backward compatibility / migration

Decryption tries each seed candidate in order (`EMAIL_MCP_KEY` -> machine id ->
legacy hostname). Files written by older versions, or before a hostname change,
still decrypt and are then transparently re-encrypted with the preferred seed —
no manual recovery, no breaking change for existing users.

## Validation

- `npx vitest run tests/auth/credential-store.test.ts` -> **10 passed** (7 existing + 3 new: env-key round-trip, wrong-key rejection, legacy->env migration)
- `node build.mjs` -> **Build complete** (esbuild)
- Minimal diff; no new dependencies; no generated artifacts.

> Note: the repo currently has no CI workflow and 17 unrelated pre-existing test
> failures in the IMAP/iCloud suites (stale `fetchAll` mocks); I'm opening a
> separate PR for those.

Fixes #4
