### PR TITLE
fix(imap): STATUS-confirm empty folders before short-circuiting search; repair stale fetchAll mocks

### DIFF
--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -224,7 +224,18 @@ export class ImapAdapter implements EmailProvider {
     }
 
     try {
-      const mailboxExists = (this.client as any).mailbox?.exists ?? 0;
+      let mailboxExists = (this.client as any).mailbox?.exists ?? 0;
+      if (mailboxExists === 0) {
+        // Some servers (notably iCloud for Junk/Trash) report exists: 0 on
+        // SELECT even when the folder has messages. Confirm with STATUS before
+        // short-circuiting so search doesn't silently return nothing.
+        try {
+          const status = await this.client.status(folder, { messages: true });
+          mailboxExists = status?.messages ?? 0;
+        } catch {
+          mailboxExists = 0;
+        }
+      }
       if (mailboxExists === 0) {
         return [];
       }

--- a/tests/providers/icloud.test.ts
+++ b/tests/providers/icloud.test.ts
@@ -41,6 +41,23 @@ vi.mock('imapflow', () => {
         yield* mockFetchImpl(range, opts);
       }
     });
+    // ImapFlow.fetchAll() resolves to an array. The adapter uses it for body
+    // fetches (a comma-joined UID list) and for the UID-collection fallback
+    // (sequence ranges like '1:*'). Normalize a comma list to a UID array so
+    // the test generators' Array.isArray branch fires, and surface generator
+    // errors as a rejected promise to mirror real fetchAll behaviour.
+    fetchAll = vi.fn().mockImplementation((range: any, opts: any) => {
+      if (!mockFetchImpl) return Promise.resolve([]);
+      const normalized =
+        typeof range === 'string' && range.includes(',')
+          ? range.split(',').map((n) => parseInt(n, 10))
+          : range;
+      try {
+        return Promise.resolve([...mockFetchImpl(normalized, opts)]);
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    });
     fetchOne = vi.fn().mockResolvedValue(null);
     messageMove = vi.fn().mockResolvedValue(undefined);
     messageDelete = vi.fn().mockResolvedValue(undefined);

--- a/tests/providers/imap.test.ts
+++ b/tests/providers/imap.test.ts
@@ -88,6 +88,27 @@ vi.mock('imapflow', () => {
       }
     });
 
+    // ImapFlow.fetchAll() resolves to an array (used by the adapter for body
+    // fetches and the UID-collection fallback). The adapter passes a
+    // comma-joined UID list for body fetches and a sequence range (e.g. '1:*')
+    // for the fallback, so mirror that here: filter by UID for a comma list,
+    // otherwise return every message.
+    fetchAll = vi.fn().mockImplementation((range: number[] | string) => {
+      let uidSet: Set<number> | null = null;
+      if (Array.isArray(range)) {
+        uidSet = new Set(range);
+      } else if (typeof range === 'string' && range.includes(',')) {
+        uidSet = new Set(range.split(',').map((n) => parseInt(n, 10)));
+      }
+      const out: any[] = [];
+      for (const msg of mockFetchMessages) {
+        if (!uidSet || uidSet.has(msg.uid)) {
+          out.push(msg);
+        }
+      }
+      return Promise.resolve(out);
+    });
+
     fetchOne = vi.fn().mockImplementation(() => {
       return Promise.resolve(mockFetchMessages[0] || null);
     });


### PR DESCRIPTION
## Problem

`ImapAdapter.search()` short-circuits and returns `[]` whenever the SELECTed
mailbox reports `exists === 0`:

```ts
const mailboxExists = (this.client as any).mailbox?.exists ?? 0;
if (mailboxExists === 0) {
  return [];
}
```

iCloud reports `exists: 0` on `SELECT` for **Junk/Trash** even when the folder
has messages (the same quirk addressed in commit e382e4e for "Invalid message
number"). As a result, `search()` silently returns nothing for those folders.

While confirming this I also found the IMAP/iCloud test suites were **red on
`main`** (17 failures): the adapter migrated from `fetch()` (async iterator) to
`fetchAll()` in e382e4e, but the ImapFlow test mocks still only implemented the
old `fetch()` API — so the very tests that guard this behaviour never ran. There
is no CI workflow in the repo, so this went unnoticed.

## Fix

1. **Product** — before short-circuiting, confirm with `STATUS (MESSAGES)`. Only
   return early when STATUS also reports `0`; a positive (or unknown/`-1`) count
   proceeds to search, matching the existing iCloud fallback chain.

2. **Tests** — add `fetchAll()` to the imap and icloud ImapFlow mocks, mirroring
   how the adapter calls it (comma-joined UID list for body fetches, sequence
   ranges like `1:*` for the fallback). This restores the regression coverage
   that should have caught the bug.

## Validation

- `npx vitest run` -> **233 passed** (was 216 passed / **17 failed**)
- `npx vitest run tests/providers/imap.test.ts tests/providers/icloud.test.ts` -> **54 passed**
- `node build.mjs` -> **Build complete**
- Minimal diff (50 lines); no new dependencies; no generated artifacts.
